### PR TITLE
Volume Drips automatically deactivate when there are no more tokens

### DIFF
--- a/contracts/drip/BalanceDripManager.sol
+++ b/contracts/drip/BalanceDripManager.sol
@@ -23,13 +23,11 @@ library BalanceDripManager {
   /// @param measure The measure token
   /// @param dripToken The drip token
   /// @param dripRatePerSecond The amount of the drip token to be dripped per second
-  /// @param currentTime The current time
   function activateDrip(
     State storage self,
     address measure,
     address dripToken,
-    uint256 dripRatePerSecond,
-    uint32 currentTime
+    uint256 dripRatePerSecond
   )
     internal
   {
@@ -39,7 +37,7 @@ library BalanceDripManager {
     }
     self.activeBalanceDrips[measure].addAddress(dripToken);
     self.balanceDrips[measure][dripToken].resetTotalDripped();
-    self.balanceDrips[measure][dripToken].setDripRate(IERC20(measure).totalSupply(), dripRatePerSecond, currentTime);
+    self.balanceDrips[measure][dripToken].dripRatePerSecond = dripRatePerSecond;
   }
 
   /// @notice Deactivates an active balance drip.  The balance drip is removed from the active balance drips list.
@@ -54,12 +52,14 @@ library BalanceDripManager {
     address measure,
     address dripToken,
     address prevDripToken,
-    uint32 currentTime
+    uint32 currentTime,
+    uint256 maxNewTokens
   )
     internal
   {
     self.activeBalanceDrips[measure].removeAddress(prevDripToken, dripToken);
-    self.balanceDrips[measure][dripToken].setDripRate(IERC20(measure).totalSupply(), 0, currentTime);
+    self.balanceDrips[measure][dripToken].drip(IERC20(measure).totalSupply(), currentTime, maxNewTokens);
+    self.balanceDrips[measure][dripToken].dripRatePerSecond = 0;
   }
 
   /// @notice Gets a list of active balance drip tokens
@@ -76,9 +76,17 @@ library BalanceDripManager {
   /// @param dripToken The drip token
   /// @param dripRatePerSecond The amount to drip of the token each second
   /// @param currentTime The current time.
-  function setDripRate(State storage self, address measure, address dripToken, uint256 dripRatePerSecond, uint32 currentTime) internal {
+  function setDripRate(
+    State storage self,
+    address measure,
+    address dripToken,
+    uint256 dripRatePerSecond,
+    uint32 currentTime,
+    uint256 maxNewTokens
+  ) internal {
     require(self.activeBalanceDrips[measure].contains(dripToken), "BalanceDripManager/drip-not-active");
-    self.balanceDrips[measure][dripToken].setDripRate(IERC20(measure).totalSupply(), dripRatePerSecond, currentTime);
+    self.balanceDrips[measure][dripToken].drip(IERC20(measure).totalSupply(), currentTime, maxNewTokens);
+    self.balanceDrips[measure][dripToken].dripRatePerSecond = dripRatePerSecond;
   }
 
   /// @notice Returns whether or not a drip is active for the given measure, dripToken pair

--- a/contracts/test/BalanceDripExposed.sol
+++ b/contracts/test/BalanceDripExposed.sol
@@ -5,6 +5,10 @@ import "../drip/BalanceDrip.sol";
 contract BalanceDripExposed {
   using BalanceDrip for BalanceDrip.State;
 
+  event DrippedTotalSupply(
+    uint256 newTokens
+  );
+
   event Dripped(
     address indexed user,
     uint256 newTokens
@@ -13,18 +17,32 @@ contract BalanceDripExposed {
   BalanceDrip.State internal dripState;
 
   function setDripRate(
-    uint256 measureTotalSupply,
-    uint256 dripRatePerSecond,
-    uint32 currentTime
+    uint256 dripRatePerSecond
   ) external {
-    dripState.setDripRate(measureTotalSupply, dripRatePerSecond, currentTime);
+    dripState.dripRatePerSecond = dripRatePerSecond;
   }
 
-  function poke(
+  function drip(
+    uint256 measureTotalSupply,
+    uint256 currentTime,
+    uint256 maxNewTokens
+  ) external returns (uint256) {
+    uint256 newTokens = dripState.drip(
+      measureTotalSupply,
+      currentTime,
+      maxNewTokens
+    );
+
+    emit DrippedTotalSupply(newTokens);
+
+    return newTokens;
+  }
+
+  function captureNewTokensForUser(
     address user,
     uint256 userMeasureBalance
-  ) external returns (uint256) {
-    uint256 newTokens = dripState.poke(
+  ) external returns (uint128) {
+    uint128 newTokens = dripState.captureNewTokensForUser(
       user,
       userMeasureBalance
     );
@@ -34,45 +52,24 @@ contract BalanceDripExposed {
     return newTokens;
   }
 
-  function drip(
-    address user,
-    uint256 userMeasureBalance,
-    uint256 measureTotalSupply,
-    uint256 currentTime
-  ) external returns (uint256) {
-    uint256 newTokens = dripState.drip(
-      user,
-      userMeasureBalance,
-      measureTotalSupply,
-      currentTime
-    );
-
-    emit Dripped(user, newTokens);
-
-    return newTokens;
-  }
-
   function dripTwice(
-    address user,
-    uint256 userMeasureBalance,
     uint256 measureTotalSupply,
-    uint256 currentTime
+    uint256 currentTime,
+    uint256 maxNewTokens
   ) external returns (uint256) {
     uint256 newTokens = dripState.drip(
-      user,
-      userMeasureBalance,
       measureTotalSupply,
-      currentTime
+      currentTime,
+      maxNewTokens
     );
 
     newTokens = newTokens + dripState.drip(
-      user,
-      userMeasureBalance,
       measureTotalSupply,
-      currentTime
+      currentTime,
+      maxNewTokens
     );
 
-    emit Dripped(user, newTokens);
+    emit DrippedTotalSupply(newTokens);
 
     return newTokens;
   }

--- a/contracts/test/BalanceDripManagerExposed.sol
+++ b/contracts/test/BalanceDripManagerExposed.sol
@@ -7,24 +7,24 @@ contract BalanceDripManagerExposed {
 
   BalanceDripManager.State dripManager;
 
-  function activateDrip(address measure, address dripToken, uint256 dripRatePerSecond, uint32 currentTime) external {
-    dripManager.activateDrip(measure, dripToken, dripRatePerSecond, currentTime);
+  function activateDrip(address measure, address dripToken, uint256 dripRatePerSecond) external {
+    dripManager.activateDrip(measure, dripToken, dripRatePerSecond);
   }
 
-  function deactivateDrip(address measure, address prevDripToken, address dripToken, uint32 currentTime) external {
-    dripManager.deactivateDrip(measure, prevDripToken, dripToken, currentTime);
-  }
-
-  function getActiveBalanceDrips(address measure) external view returns(address[] memory) {
-    return dripManager.getActiveBalanceDrips(measure);
+  function deactivateDrip(address measure, address prevDripToken, address dripToken, uint32 currentTime, uint256 maxNewTokens) external {
+    dripManager.deactivateDrip(measure, prevDripToken, dripToken, currentTime, maxNewTokens);
   }
 
   function isDripActive(address measure, address dripToken) external view returns (bool) {
     return dripManager.isDripActive(measure, dripToken);
   }
 
-  function setDripRate(address measure, address dripToken, uint256 dripRatePerSecond, uint32 currentTime) external {
-    dripManager.setDripRate(measure, dripToken, dripRatePerSecond, currentTime);
+  function setDripRate(address measure, address dripToken, uint256 dripRatePerSecond, uint32 currentTime, uint256 maxNewTokens) external {
+    dripManager.setDripRate(measure, dripToken, dripRatePerSecond, currentTime, maxNewTokens);
+  }
+
+  function getActiveBalanceDrips(address measure) external view returns (address[] memory) {
+    return dripManager.getActiveBalanceDrips(measure);
   }
 
   function getDrip(

--- a/contracts/test/VolumeDripExposed.sol
+++ b/contracts/test/VolumeDripExposed.sol
@@ -6,7 +6,8 @@ contract VolumeDripExposed {
   using VolumeDrip for VolumeDrip.State;
 
   event DripTokensBurned(address user, uint256 amount);
-  event Minted(uint256 amount, bool isNewPeriod);
+  event Minted(uint256 amount);
+  event MintedTotalSupply(uint256 amount);
 
   VolumeDrip.State state;
 
@@ -18,16 +19,20 @@ contract VolumeDripExposed {
     state.setNextPeriod(periodSeconds, dripAmount);
   }
 
-  function poke(uint256 currentTime) external returns (bool) {
-    return state.poke(currentTime);
+  function drip(uint256 currentTime, uint256 maxNewTokens) external returns (uint256) {
+    uint256 newTokens = state.drip(currentTime, maxNewTokens);
+
+    emit MintedTotalSupply(newTokens);
+
+    return newTokens;
   }
 
-  function mint(address user, uint256 amount, uint256 currentTime) external returns (uint256 accrued, bool isNewPeriod) {
-    (accrued, isNewPeriod) = state.mint(user, amount, currentTime);
+  function mint(address user, uint256 amount) external returns (uint256) {
+    uint256 accrued = state.mint(user, amount);
 
-    emit Minted(accrued, isNewPeriod);
+    emit Minted(accrued);
 
-    return (accrued, isNewPeriod);
+    return accrued;
   }
 
   function getDrip()

--- a/contracts/test/VolumeDripManagerExposed.sol
+++ b/contracts/test/VolumeDripManagerExposed.sol
@@ -30,10 +30,6 @@ contract VolumeDripManagerExposed {
     manager.deactivate(measure, dripToken, prevDripToken);
   }
 
-  function getActiveVolumeDrips(address measure) external view returns(address[] memory) {
-    return manager.getActiveVolumeDrips(measure);
-  }
-
   function set(address measure, address dripToken, uint32 periodSeconds, uint112 dripAmount) external {
     manager.set(measure, dripToken, periodSeconds, dripAmount);
   }
@@ -60,6 +56,10 @@ contract VolumeDripManagerExposed {
     totalSupply = state.totalSupply;
     dripAmount = state.dripAmount;
     endTime = state.endTime;
+  }
+
+  function getActiveVolumeDrips(address measure) external view returns (address[] memory) {
+    return manager.getActiveVolumeDrips(measure);
   }
 
   function getDrip(

--- a/test/BalanceDripManagerExposed.test.js
+++ b/test/BalanceDripManagerExposed.test.js
@@ -38,29 +38,29 @@ describe('BalanceDripManagerExposed', function() {
 
   describe('activateDrip()', () => {
     it('should activate a drip token', async () => {
-      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'), '1')
+      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'))
       expect(await dripExposed.isDripActive(measure.address, drip1.address)).to.be.true
     })
 
     it('should support a second drip token', async () => {
-      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'), '1')
-      await dripExposed.activateDrip(measure.address, drip2.address, toWei('0.001'), '1')
+      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'))
+      await dripExposed.activateDrip(measure.address, drip2.address, toWei('0.001'))
       expect(await dripExposed.isDripActive(measure.address, drip1.address)).to.be.true
       expect(await dripExposed.isDripActive(measure.address, drip2.address)).to.be.true
     })
 
     it('should not add a drip token twice', async () => {
-      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'), '1')
-      await expect(dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'), '2')).to.be.revertedWith('BalanceDripManager/drip-active')
+      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'))
+      await expect(dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'))).to.be.revertedWith('BalanceDripManager/drip-active')
     })
   })
 
   describe('deactivateDrip()', () => {
     it('should allow a drip to be deactivated', async () => {
-      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'), '1')
+      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'))
       expect(await dripExposed.isDripActive(measure.address, drip1.address)).to.be.true
 
-      await dripExposed.deactivateDrip(measure.address, drip1.address, SENTINAL, '2')
+      await dripExposed.deactivateDrip(measure.address, drip1.address, SENTINAL, '2', toWei('100'))
       expect(await dripExposed.isDripActive(measure.address, drip1.address)).to.be.false
 
       let detail = await dripExposed.getDrip(measure.address, drip1.address);
@@ -70,8 +70,7 @@ describe('BalanceDripManagerExposed', function() {
 
   describe('getActiveBalanceDrips()', () => {
     it('should return a list of active balance drip tokens', async () => {
-      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'), '1')
-
+      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'))
       expect(await dripExposed.getActiveBalanceDrips(measure.address))
         .to.deep.equal([drip1.address])
     })
@@ -79,13 +78,13 @@ describe('BalanceDripManagerExposed', function() {
 
   describe('setDripRate()', () => {
     it('should revert when setting drips that are not active', async () => {
-      await expect(dripExposed.setDripRate(measure.address, invalidDrip, toWei('0.001'), '1'))
+      await expect(dripExposed.setDripRate(measure.address, invalidDrip, toWei('0.001'), '1', toWei('100')))
         .to.be.revertedWith('BalanceDripManager/drip-not-active')
     })
 
     it('should allow the drip rate to be changed', async () => {
-      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'), '1')
-      await dripExposed.setDripRate(measure.address, drip1.address, toWei('0.1'), '2')
+      await dripExposed.activateDrip(measure.address, drip1.address, toWei('0.001'))
+      await dripExposed.setDripRate(measure.address, drip1.address, toWei('0.1'), '2', toWei('100'))
 
       let detail = await dripExposed.getDrip(measure.address, drip1.address)
 

--- a/test/VolumeDripExposed.test.js
+++ b/test/VolumeDripExposed.test.js
@@ -10,15 +10,16 @@ const toWei = ethers.utils.parseEther
 
 const debug = require('debug')('ptv3:VolumeDripExposed.test')
 
-let overrides = { gasLimit: 20000000 }
 
 describe('VolumeDripExposed', function() {
 
   let drip
 
-  let periodSeconds = 10
-  let dripAmount = toWei('10')
-  let endTime = 30
+  const overrides = { gasLimit: 20000000 }
+  const periodSeconds = 10
+  const dripAmount = toWei('10')
+  const endTime = 30
+  const unlimitedTokens = toWei('10000000')
 
   beforeEach(async () => {
     [wallet, wallet2, wallet3, wallet4] = await buidler.ethers.getSigners()
@@ -43,37 +44,86 @@ describe('VolumeDripExposed', function() {
 
   describe('setNextPeriod()', () => {
     it('should set the values for the next period', async () => {
-      await drip.setNextPeriod(5, toWei('5'))
-      expect(await call(drip, 'poke', 30)).to.be.true
-      await drip.poke(30)
+      const newPeriodLength = 5
+      const newDripAmount = toWei('10')
 
-      let period = await drip.getPeriod(2)
-      expect(period.endTime).to.equal(35)
-      expect(period.dripAmount).to.equal(toWei('5'))
+      await drip.setNextPeriod(newPeriodLength, newDripAmount)
+
+      // ensure there is a deposit for the first period
+      await drip.mint(wallet._address, toWei('11'))
+
+      await expect(
+        drip.drip(endTime, unlimitedTokens)
+      )
+        .to.emit(drip, 'MintedTotalSupply')
+        .withArgs(dripAmount)
+
+      // ensure there is a deposit for the next period
+      await drip.mint(wallet._address, toWei('11'))
+
+      await expect(
+        drip.drip(endTime + newPeriodLength, unlimitedTokens)
+      )
+        .to.emit(drip, 'MintedTotalSupply')
+        .withArgs(newDripAmount)
     })
   })
 
-  describe('poke()', () => {
-    it('should complete the period when it is over', async () => {
-      expect(await call(drip, 'poke', 30)).to.be.true
-      await drip.poke(30)
-      expect((await drip.getPeriod(2)).endTime).to.equal(40)
-      await drip.poke(40)
-      expect((await drip.getPeriod(3)).endTime).to.equal(50)
+  describe('drip()', () => {
+    it('should not drip anything if there were no deposits', async () => {
+      await expect(
+        drip.drip(endTime, unlimitedTokens)
+      )
+        .to.emit(drip, 'MintedTotalSupply')
+        .withArgs('0')
+
+      const nextPeriod = await drip.getPeriod(2)
+      expect(nextPeriod.endTime).to.equal(endTime + periodSeconds)
+      expect(nextPeriod.dripAmount).to.equal(dripAmount)
     })
 
-    it('should not complete the period when the period is not over', async () => {
-      expect(await call(drip, 'poke', 25)).to.be.false
-      await drip.poke(25)
-      expect((await drip.getPeriod(2)).endTime).to.equal(0)
+    it('should drip if there are deposits', async () => {
+      // ensure there is a deposit
+      await drip.mint(wallet._address, toWei('11'))
+
+      await expect(
+        drip.drip(endTime, unlimitedTokens)
+      )
+        .to.emit(drip, 'MintedTotalSupply')
+        .withArgs(dripAmount)
+
+      const nextPeriod = await drip.getPeriod(2)
+      expect(nextPeriod.endTime).to.equal(endTime + periodSeconds)
+      expect(nextPeriod.dripAmount).to.equal(dripAmount)
+    })
+
+    it('should cap the drip amount by the max', async () => {
+      // ensure there is a deposit
+      await drip.mint(wallet._address, toWei('11'))
+
+      const maxDripAmount = toWei('1')
+
+      await expect(
+        drip.drip(endTime, maxDripAmount)
+      )
+        .to.emit(drip, 'MintedTotalSupply')
+        .withArgs(maxDripAmount)
+    })
+
+    it('should not drip if the period is not over', async () => {
+      await expect(
+        drip.drip(endTime / 2, unlimitedTokens)
+      )
+        .to.emit(drip, 'MintedTotalSupply')
+        .withArgs('0')
     })
   })
 
   describe('mint()', () => {
     it('should increment a users balance and set their current period', async () => {
-      await expect(drip.mint(wallet._address, toWei('10'), 20))
+      await expect(drip.mint(wallet._address, toWei('10')))
         .to.emit(drip, 'Minted')
-        .withArgs(0, false)
+        .withArgs(0)
 
       let deposit = await drip.getDeposit(wallet._address)
       expect(deposit.balance).to.equal(toWei('10'))
@@ -81,13 +131,13 @@ describe('VolumeDripExposed', function() {
     })
 
     it('should update their balance when depositing again', async () => {
-      await expect(drip.mint(wallet._address, toWei('10'), 20))
+      await expect(drip.mint(wallet._address, toWei('10')))
         .to.emit(drip, 'Minted')
-        .withArgs(0, false)
+        .withArgs(0)
 
-      await expect(drip.mint(wallet._address, toWei('20'), 25))
+      await expect(drip.mint(wallet._address, toWei('20')))
         .to.emit(drip, 'Minted')
-        .withArgs(0, false)
+        .withArgs(0)
 
       let deposit = await drip.getDeposit(wallet._address)
       expect(deposit.balance).to.equal(toWei('30'))
@@ -96,28 +146,36 @@ describe('VolumeDripExposed', function() {
 
     it('should accrue their previous amounts', async () => {
       // Period 1 now
-      await expect(drip.mint(wallet._address, toWei('10'), 20))
+      await expect(drip.mint(wallet._address, toWei('10')))
         .to.emit(drip, 'Minted')
-        .withArgs(0, false)
+        .withArgs(0)
 
       // Period 1 still
-      await expect(drip.mint(wallet._address, toWei('20'), 25))
+      await expect(drip.mint(wallet._address, toWei('20')))
         .to.emit(drip, 'Minted')
-        .withArgs(0, false)
+        .withArgs(0)
+
+      await expect(drip.drip(endTime, unlimitedTokens))
+        .to.emit(drip, 'MintedTotalSupply')
+        .withArgs(dripAmount)
 
       // Period 2 now
-      await expect(drip.mint(wallet._address, toWei('20'), 35))
+      await expect(drip.mint(wallet._address, toWei('20')))
         .to.emit(drip, 'Minted')
-        .withArgs(toWei('10'), true)
+        .withArgs(dripAmount)
 
-      await expect(drip.mint(wallet._address, toWei('20'), 37))
+      await expect(drip.mint(wallet._address, toWei('20')))
         .to.emit(drip, 'Minted')
-        .withArgs(0, false)
+        .withArgs(0)
+
+      await expect(drip.drip(endTime + periodSeconds, unlimitedTokens))
+        .to.emit(drip, 'MintedTotalSupply')
+        .withArgs(dripAmount)
 
       // try minting zero for period 3
-      await expect(drip.mint(wallet._address, toWei('0'), 40))
+      await expect(drip.mint(wallet._address, toWei('0')))
         .to.emit(drip, 'Minted')
-        .withArgs(toWei('10'), true)
+        .withArgs(dripAmount)
     })
   })
 });

--- a/test/VolumeDripManagerExposed.test.js
+++ b/test/VolumeDripManagerExposed.test.js
@@ -74,7 +74,7 @@ describe('VolumeDripManagerExposed', function() {
       expect(await manager.isActive(measure.address, drip1.address)).to.be.false
     })
   })
-
+ 
   describe('getActiveVolumeDrips()', () => {
     it('should return a list of active volume drip tokens', async () => {
       await manager.activate(measure.address, drip1.address, periodSeconds, dripAmount, 30)


### PR DESCRIPTION
Note: this pulls in a forgotten refactoring.  It *does* clean the code up, if being somewhat large.