### PR TITLE
Optimized capture tokens for user

### DIFF
--- a/contracts/token-faucet/TokenFaucet.sol
+++ b/contracts/token-faucet/TokenFaucet.sol
@@ -161,9 +161,13 @@ contract TokenFaucet is OwnableUpgradeable, TokenListener {
   function _captureNewTokensForUser(
     address user
   ) private returns (uint128) {
-    uint256 userMeasureBalance = measure.balanceOf(user);
     UserState storage userState = userStates[user];
+    if (exchangeRateMantissa == userState.lastExchangeRateMantissa) {
+      // ignore if exchange rate is same
+      return 0;
+    }
     uint256 deltaExchangeRateMantissa = uint256(exchangeRateMantissa).sub(userState.lastExchangeRateMantissa);
+    uint256 userMeasureBalance = measure.balanceOf(user);
     uint128 newTokens = FixedPoint.multiplyUintByMantissa(userMeasureBalance, deltaExchangeRateMantissa).toUint128();
 
     userStates[user] = UserState({


### PR DESCRIPTION
- If there are two transfers in the same block, then we only need to
  drip once.