### PR TITLE
Remove cli.js bin entry from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "3.3.8",
   "description": "PoolManager Prize Linked Savings Account Pool Smart Contracts",
   "main": "index.js",
-  "bin": {
-    "pt-cli": "./scripts/cli.js"
-  },
   "license": "GPL-3.0",
   "scripts": {
     "reinstall": "rm -rf node_modules/ && rm -f yarn.lock && yarn",


### PR DESCRIPTION
Hello and thanks for creating PoolTogether! 🌈 

Minor change: `scripts/cli.js` was removed in 60d24217006f81b83325dc0510e46d128b5e648e yet is still referenced in package.json's `bin` entry, resulting in an install error. Since I don't see a direct replacement, I've removed the `bin` entry.