### PR TITLE
Audit Issue 85 resolution: Reserve Fee capture-able twice

### DIFF
--- a/contracts/prize-pool/PrizePool.sol
+++ b/contracts/prize-pool/PrizePool.sol
@@ -448,6 +448,11 @@ abstract contract PrizePool is PrizePoolInterface, OwnableUpgradeable, Reentranc
   /// @dev This function also captures the reserve fees.
   /// @return The total amount of assets to be awarded for the current prize
   function captureAwardBalance() external override nonReentrant returns (uint256) {
+    return _captureAwardBalance();
+  }
+
+  /// @notice Internal wrapper for captureAwardBalance
+  function _captureAwardBalance() internal returns (uint256) {
     uint256 tokenTotalSupply = _tokenTotalSupply();
 
     // it's possible for the balance to be slightly less due to rounding errors in the underlying yield source

--- a/contracts/test/PrizePoolHarness.sol
+++ b/contracts/test/PrizePoolHarness.sol
@@ -66,4 +66,13 @@ contract PrizePoolHarness is PrizePool {
   function _redeem(uint256 redeemAmount) internal override returns (uint256) {
     return stubYieldSource.redeem(redeemAmount);
   }
+  
+  function captureAwardBalanceMultipleTimes(uint256 numTimes) external returns(uint256) {
+
+    uint256 result = 0;
+    for(uint256 i = 0; i < numTimes; i++){
+      result += _captureAwardBalance();
+    }
+    return result;
+  }
 }


### PR DESCRIPTION
proof that issue https://github.com/code-423n4/2021-06-pooltogether-findings/issues/85 is a non-issue.

do not merge.