### PR TITLE
Update MultipleWinnersBuilder.sol: Packed Structs

### DIFF
--- a/contracts/builders/MultipleWinnersBuilder.sol
+++ b/contracts/builders/MultipleWinnersBuilder.sol
@@ -13,6 +13,7 @@ contract MultipleWinnersBuilder {
 
   struct MultipleWinnersConfig {
     RNGInterface rngService;
+    bool splitExternalErc20Awards;
     uint256 prizePeriodStart;
     uint256 prizePeriodSeconds;
     string ticketName;
@@ -23,7 +24,6 @@ contract MultipleWinnersBuilder {
     uint256 ticketCreditRateMantissa;
     uint256 numberOfWinners;
     MultipleWinners.PrizeSplitConfig[] prizeSplits;
-    bool splitExternalErc20Awards;
   }
 
   MultipleWinnersProxyFactory public multipleWinnersProxyFactory;


### PR DESCRIPTION
Well, this PR made a slight change within the elements of that struct which avoids usage of 1 extra slot. Usually, EVM allocates 2**256 slots to each contract and each slot comprises of 32 bytes. And the usage of slots costs us gas, which makes it better if any contract is achieving the same thing in less slots.
Let's suppose there are two structs:
```
Struct A {
    address abc; // 1st slot - covers up 20 bytes
    uint256 num; // 2nd slot - covers up 32 bytes
    bool isTrue; // 3rd slot - covers up 1 byte
}
``` 
Now, Struct A uses up 3 slots and is 3rd slot seems kind of expensive cuz only 1 byte is allotted to that entire 32 bytes slot..Let's optimize this

```
Struct B {
    address abc; // 1st slot - covers up 20 bytes
    bool isTrue; // 1st slot - covers up (20 + 1) byte
    uint256 num; // 2nd slot - covers up 32 bytes
}
```
Well, this makes sense and we neglected the usage of 1 slot by optimizing Struct A to Struct B. The same thing is done with the help of this PR. Note that `RNGInterface rngService` is a kind of address as far I am concerned.

For a better explanation, refer [this](https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#pack-structs-in-solidity)

Thanks @PierrickGT